### PR TITLE
CircleCI Setup testing with debian slim image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 jobs:
-  build:
+  test:
     docker:
-      - image: samsoir/alpine-shunit2:1.2
+      - image: samsoir/debian-shunit2:1.0
         auth:
           username: samsoir
           password: $DOCKERHUB_PASSWORD
@@ -13,13 +13,12 @@ jobs:
           command: |
             bash install.sh
             ln -s /usr/local/go/bin/go /usr/local/bin/go
-            echo $PATH
-      - run:
-          name: Verfiy Go installed
-          command: |
-            ls -la /usr/local/go/bin
-            go version
       - run:
           name: Test Golang Version installed
           command: |
             examples/test_go_version.sh
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test

--- a/.docker/Dockerfile.base
+++ b/.docker/Dockerfile.base
@@ -1,7 +1,5 @@
-FROM alpine:3.7
-RUN apk update
-RUN apk add git
-RUN apk add bash
+FROM amd64/debian:9.13-slim 
+RUN apt-get update && apt-get install -y apt-utils wget git
 
 RUN git clone https://github.com/kward/shunit2.git
 RUN cp shunit2/shunit2 /usr/local/bin/shunit2

--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -1,0 +1,3 @@
+FROM samsoir/debian-shunit2:latest
+
+COPY ./ /

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,26 @@
 DOCKER_BUILD_OPTS    :=--no-cache
-DOCKER_BUILD_REPO    :=samsoir/alpine-shunit2
+DOCKER_BUILD_REPO    :=samsoir/debian-shunit2
 DOCKER_BUILD_LATEST  :=latest
-DOCKER_BUILD_VERSION :=1.2
+DOCKER_BUILD_VERSION :=1.0
+DOCKER_TEST_NAME     :=go-development-test
 
 .PHONY: test build-base push 
 
 test:
-	@echo "Tests will run here"
+	docker build $(DOCKER_BUILD_OPTS) -f .docker/Dockerfile.test -t $(DOCKER_TEST_NAME) .
+	docker run --name $(DOCKER_TEST_NAME) --rm -d -t $(DOCKER_TEST_NAME) /bin/bash
+	docker exec $(DOCKER_TEST_NAME) ./install.sh && echo "PATH=\$PATH:/usr/local/bin/go" >> ~/.bashrc
+	docker exec $(DOCKER_TEST_NAME) examples/test_go_version.sh
+	docker container kill $(DOCKER_TEST_NAME)
 
 build-base: 
 	@echo "Building Docker container"
-	docker build $(DOCKER_BUILD_OPTS) -f Dockerfile -t ${DOCKER_BUILD_REPO}:$(DOCKER_BUILD_LATEST) -t $(DOCKER_BUILD_REPO):$(DOCKER_BUILD_VERSION) .
+	docker build $(DOCKER_BUILD_OPTS) -f .docker/Dockerfile.base -t ${DOCKER_BUILD_REPO}:$(DOCKER_BUILD_LATEST) -t $(DOCKER_BUILD_REPO):$(DOCKER_BUILD_VERSION) .
 
 push:
+	@echo "Pushing current container to Dockerhub $(DOCKER_BUILD_REPO)"
+	docker push $(DOCKER_BUILD_REPO):$(DOCKER_BUILD_VERSION)
+
+push-latest:
 	@echo "Pushing latest container to Dockerhub $(DOCKER_BUILD_REPO)"
 	docker push $(DOCKER_BUILD_REPO):$(DOCKER_BUILD_LATEST)

--- a/examples/equality_test.sh
+++ b/examples/equality_test.sh
@@ -1,9 +1,0 @@
-#! /bin/sh
-# file: examples/equality_test.sh
-
-testEquality() {
-  assertEquals 1 1
-}
-
-# Test runner
-. shunit2


### PR DESCRIPTION
- Change image type to debian to match current target
- Updated Makefile to allow for local testing
- Split base image from test image
- Updated CircleCI config to name the job as a test, instead of build